### PR TITLE
fixed nether mini hp hud

### DIFF
--- a/features/nether/index.js
+++ b/features/nether/index.js
@@ -143,6 +143,7 @@ class Nether extends Feature {
 			this.controlLocLast = undefined
 			this.controlLoc = undefined
 			this.controlSkeleton = undefined
+            this.miniboss = undefined
 		})
 
 		this.registerChat("You completed your rescue quest! Visit the Town Board to claim the rewards,", () => {


### PR DESCRIPTION
= nether miniboss hp hud not disappearing after leaving nether (if left mid boss fight/ dead)