### PR TITLE
made powder chat registries work

### DIFF
--- a/src/features/specialMining/index.js
+++ b/src/features/specialMining/index.js
@@ -207,7 +207,7 @@ class PowderAndScatha extends Feature {
         this.lastPowderReceived = { mithril: 0, gemstone: 0 }
         this.lastPowderReceivedExecuted = false;
         this.registerChat("&r&aYou received &r&b+${amount} &r&aMithril Powder.&r", (amount, e) => {
-            let p = (this.dPowder ? 2 : 1) * parseInt(amount)
+            let p = (this.dPowder ? 2 : 1) * parseInt(amount.replace(",", ""))
             this.miningData.powder.mithril += p
             if (this.compactedChat.getValue()) {
                 cancel(e)
@@ -217,7 +217,7 @@ class PowderAndScatha extends Feature {
             }
         })
         this.registerChat("&r&aYou received &r&b+${amount} &r&aGemstone Powder.&r", (amount, e) => {
-            let p = (this.dPowder ? 2 : 1) * parseInt(amount)
+            let p = (this.dPowder ? 2 : 1) * parseInt(amount.replace(",", ""))
             this.miningData.powder.gemstone += p
             if (this.compactedChat.getValue()) {
                 cancel(e)

--- a/src/features/specialMining/index.js
+++ b/src/features/specialMining/index.js
@@ -206,7 +206,7 @@ class PowderAndScatha extends Feature {
 
         this.lastPowderReceived = { mithril: 0, gemstone: 0 }
         this.lastPowderReceivedExecuted = false;
-        this.registerChat("&r&aYou received &r&b+${amount} &r&aMithril Powder&r", (amount, e) => {
+        this.registerChat("&r&aYou received &r&b+${amount} &r&aMithril Powder.&r", (amount, e) => {
             let p = (this.dPowder ? 2 : 1) * parseInt(amount)
             this.miningData.powder.mithril += p
             if (this.compactedChat.getValue()) {
@@ -216,7 +216,7 @@ class PowderAndScatha extends Feature {
                 return
             }
         })
-        this.registerChat("&r&aYou received &r&b+${amount} &r&aGemstone Powder&r", (amount, e) => {
+        this.registerChat("&r&aYou received &r&b+${amount} &r&aGemstone Powder.&r", (amount, e) => {
             let p = (this.dPowder ? 2 : 1) * parseInt(amount)
             this.miningData.powder.gemstone += p
             if (this.compactedChat.getValue()) {


### PR DESCRIPTION
BECAUSE THEY ADDED A PERIOD (.) BEHIND THE RECEIVED BLABLABLA POWDER MESSAGE AAAAAAAAAAAAAAA